### PR TITLE
Use list comprehension to create distinct ResBlock instances

### DIFF
--- a/p1ch8/1_convolution.ipynb
+++ b/p1ch8/1_convolution.ipynb
@@ -1499,7 +1499,7 @@
     "        self.n_chans1 = n_chans1\n",
     "        self.conv1 = nn.Conv2d(3, n_chans1, kernel_size=3, padding=1)\n",
     "        self.resblocks = nn.Sequential(\n",
-    "            *(n_blocks * [ResBlock(n_chans=n_chans1)]))\n",
+    "            *[ResBlock(n_chans=n_chans1) for _ in range(n_blocks)])\n",
     "        self.fc1 = nn.Linear(8 * 8 * n_chans1, 32)\n",
     "        self.fc2 = nn.Linear(32, 2)\n",
     "        \n",
@@ -1590,7 +1590,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1604,9 +1604,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
`n_blocks * [ResBlock(...)]` creates shared reference to single object; used comprehension to create blocks with independent parameters. Verify by checking that `sum(p.numel() for p in model.parameters())` is identical for `n_blocks=1, 10, 100` (75810) with the original code.
Downstream cell outputs (training loss, accuracy) will change when the notebook is re-run.